### PR TITLE
Feat: add boss hit and deploy setting

### DIFF
--- a/Assets/Prefabs/BombMissile.prefab
+++ b/Assets/Prefabs/BombMissile.prefab
@@ -205,7 +205,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: -2
+  m_SortingOrder: 1
   m_Sprite: {fileID: 1458439812, guid: 8d0b21b2c77fa784a9a459736d7b14f3, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/Assets/Prefabs/Boss.prefab
+++ b/Assets/Prefabs/Boss.prefab
@@ -231,6 +231,7 @@ MonoBehaviour:
   LAttackPos: {fileID: 5689348737063004647}
   RAttackPos: {fileID: 8267623050781236454}
   bossBullet: {fileID: 8274459695531298979, guid: 164f5d2cdd26de54697d64d57f4ea333, type: 3}
+  spriteRenderer: {fileID: 4329320318330732685}
 --- !u!1 &7849701037128220137
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/player_0.prefab
+++ b/Assets/Prefabs/player_0.prefab
@@ -192,6 +192,6 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.00000011920929, y: -0.2201705}
-  m_Size: {x: 2.9431813, y: 3.207386}
+  m_Offset: {x: 0.007129073, y: -0.1488812}
+  m_Size: {x: 1.902354, y: 2.4089437}
   m_Direction: 0

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -1507,10 +1507,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1440, y: 2560}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -713,10 +713,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1440, y: 2560}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3

--- a/Assets/Scripts/BossController.cs
+++ b/Assets/Scripts/BossController.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 public class BossController : MonoBehaviour
 {
-    //
+    // 
     GameObject player;
     PlayerController playerController;
     // 체력바
@@ -38,6 +38,11 @@ public class BossController : MonoBehaviour
     // 2 : R공격
     // 3 : Die
     int animNumber;
+
+    // 피격관련
+    public SpriteRenderer spriteRenderer;
+    Color currentColor;
+
     private void Awake()
     {
         hpGreen = 150.0f;
@@ -57,6 +62,7 @@ public class BossController : MonoBehaviour
         speed = 10;
 
         animNumber = 0;
+        currentColor = spriteRenderer.color;
     }
 
     // Update is called once per frame
@@ -198,16 +204,25 @@ public class BossController : MonoBehaviour
         {
             if(hpGreen > 0) hpGreen -= playerController.Damage;
             else            hpRed -= playerController.Damage;
+            StartCoroutine(OnDamagedEffect());
         }
         if (collision.CompareTag("bombMissile"))
         {
             if (hpGreen > 0) hpGreen -= playerController.BombDamage;
             else             hpRed -= playerController.Damage;
+            StartCoroutine(OnDamagedEffect());
         }
         if (hpRed <= 0)
         {
             animator.SetTrigger("Die");
             OnDead();
         }
+    }
+
+    IEnumerator OnDamagedEffect()
+    {
+        spriteRenderer.color = Color.red;
+        yield return new WaitForSeconds(0.2f);
+        spriteRenderer.color = currentColor;
     }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "2.6.0",
     "com.unity.feature.2d": "2.0.1",
     "com.unity.ide.rider": "3.0.34",
     "com.unity.ide.visualstudio": "2.0.22",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -104,13 +104,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.collab-proxy": {
-      "version": "2.6.0",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.collections": {
       "version": "1.2.4",
       "depth": 2,

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -12,8 +12,8 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: DefaultCompany
-  productName: gamer_tv_clone
+  companyName: GamerTVCloneCodingCompany
+  productName: Fly Force
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
@@ -42,8 +42,8 @@ PlayerSettings:
   m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
-  defaultScreenWidth: 1920
-  defaultScreenHeight: 1080
+  defaultScreenWidth: 480
+  defaultScreenHeight: 853
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 0
@@ -104,7 +104,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0


### PR DESCRIPTION
## 📌Details
- 보스(가) 피격 시 일시적으로 빨간색이 됩니다
- 마지막으로, 배포를 위한 세팅과 약간의 자잘한 수정이 추가되어 있습니다
  - 폭탄 Order in Layer : -2 -> 1
  - player 피격 범위 더 작게 설정
  - 배포를 위한 x, y 수정
  - companyName, productName 변경

## 🎞 Screenshots / Videos
![Cap 2025-01-15 15-14-59-143](https://github.com/user-attachments/assets/4cbb9a38-e31c-4b47-bd4b-27c46d4df769)
![Cap 2025-01-15 15-17-12-622](https://github.com/user-attachments/assets/3115a63a-066e-4854-bfe8-923cf7016c01)
![Cap 2025-01-15 15-30-30-139](https://github.com/user-attachments/assets/efc85f0e-cb30-4ed7-a9d0-e639b59bd019)

## 📚 References

- 2\. 유니티가 어려운 입문자를 위한 입문용 게임 제작 - 24. 마무리 빌드
[![test](https://i.ytimg.com/vi/QHFcJnIgUEQ/hq720.jpg)](https://www.youtube.com/watch?v=QHFcJnIgUEQ)
